### PR TITLE
Integrate AI service for meal plan generation

### DIFF
--- a/meal_planning/views.py
+++ b/meal_planning/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.db import transaction
 from django.db import models
 from .models import NutritionProfile, Recipe, Ingredient, MealPlan, UserRecipeRating, NutritionLog
+from .services.ai_meal_planning_service import AIMealPlanningService
 from .serializers import (
     NutritionProfileSerializer, RecipeSerializer, IngredientSerializer,
     MealPlanSerializer, UserRecipeRatingSerializer, NutritionLogSerializer
@@ -296,7 +297,12 @@ class RecipeViewSet(viewsets.ReadOnlyModelViewSet):
         if data.get('cuisine_preferences'):
             queryset = queryset.filter(cuisine__in=data['cuisine_preferences'])
 
-        serializer = self.get_serializer(queryset[:20], many=True)
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=True, methods=['post'])
@@ -365,7 +371,7 @@ class MealPlanViewSet(viewsets.ModelViewSet):
 
     @action(detail=False, methods=['post'])
     def generate(self, request):
-        """Generate a new meal plan using AI (mock implementation for now)"""
+        """Generate a new meal plan using the AI meal planning service"""
         try:
             # Get user's nutrition profile
             nutrition_profile = get_object_or_404(NutritionProfile, user=request.user)
@@ -388,26 +394,12 @@ class MealPlanViewSet(viewsets.ModelViewSet):
             else:
                 start_date_obj = start_date
 
-            # TODO: Implement AI meal plan generation
-            # For now, return a mock response based on user's preferences
-            mock_meal_plan = self._generate_mock_meal_plan(
-                nutrition_profile,
-                start_date=start_date_obj,
-                plan_type=plan_type,
-            )
-
-            meal_plan = MealPlan.objects.create(
+            # Use the AI meal planning service to generate a full meal plan
+            ai_service = AIMealPlanningService()
+            meal_plan = ai_service.generate_meal_plan(
                 user=request.user,
                 plan_type=plan_type,
                 start_date=start_date_obj,
-                end_date=start_date_obj,  # For daily plans
-                meal_plan_data=mock_meal_plan,
-                total_calories=float(nutrition_profile.calorie_target),
-                avg_daily_calories=float(nutrition_profile.calorie_target),
-                total_protein=float(nutrition_profile.protein_target),
-                total_carbs=float(nutrition_profile.carb_target),
-                total_fat=float(nutrition_profile.fat_target),
-                ai_model_used='mock_v1.0'
             )
 
             serializer = self.get_serializer(meal_plan)

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+class StandardResultsSetPagination(PageNumberPagination):
+    """Allow client to control page size with a limit"""
+    page_size = 20
+    page_size_query_param = 'page_size'
+    max_page_size = 100

--- a/wellness_project/settings.py
+++ b/wellness_project/settings.py
@@ -203,8 +203,7 @@ REST_FRAMEWORK = {
         'user': '100/minute',
         'anon': '20/minute',
     },
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 20,
+    'DEFAULT_PAGINATION_CLASS': 'utils.pagination.StandardResultsSetPagination',
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend',
         'rest_framework.filters.SearchFilter',


### PR DESCRIPTION
## Summary
- wire up `AIMealPlanningService` in the meal plan API view
- enable pagination on recipe search results
- allow client to set page size via new pagination class

## Testing
- `pytest -q` *(fails: Django settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6866f11bb3c4832b812ede079bafedb6