### PR TITLE
Add Render deployment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,35 @@ Automatic tracking and celebration of achievements:
 - Chart.js for beautiful data visualizations
 - Vue.js community for excellent documentation
 - Django REST Framework for robust API development
+
+## 🚢 Deployment on Render.com
+
+This repository includes a `render.yaml` blueprint for deploying the project on
+[Render](https://render.com). After linking your GitHub account, create a new
+Blueprint and select this file. The blueprint provisions:
+
+1. **wellness-backend** – a Python web service running `gunicorn` with Django.
+   It installs dependencies, applies migrations, and serves static files.
+   Set the `SECRET_KEY`, `OPENAI_API_KEY`, and `SPOONACULAR_API_KEY`
+   environment variables. The service receives a `DATABASE_URL` automatically
+   from the PostgreSQL instance named **wellness-db**.
+2. **wellness-frontend** – a static site built from the `frontend` directory.
+   Render runs `npm install && npm run build` and serves the `dist` directory.
+
+If you prefer the manual approach, create these services individually on Render:
+
+```text
+Backend (Python Web Service)
+  Build Command: pip install -r requirements.txt && \
+                 python manage.py collectstatic --noinput && \
+                 python manage.py migrate --noinput
+  Start Command: gunicorn wellness_project.wsgi:application
+
+Frontend (Static Site)
+  Root Directory: frontend
+  Build Command: npm install && npm run build
+  Publish Directory: dist
+```
+
+Ensure that your environment variables match those in your local `.env` file so
+the application can run successfully on Render.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,30 @@
+services:
+  - type: web
+    name: wellness-backend
+    env: python
+    buildCommand: |
+      pip install -r requirements.txt
+      python manage.py collectstatic --noinput
+      python manage.py migrate --noinput
+    startCommand: gunicorn wellness_project.wsgi:application
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: wellness-db
+          property: connectionString
+      - key: SECRET_KEY
+        sync: false
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: SPOONACULAR_API_KEY
+        sync: false
+  - type: web
+    name: wellness-frontend
+    env: static
+    buildCommand: |
+      cd frontend && npm install && npm run build
+    staticPublishPath: frontend/dist
+
+databases:
+  - name: wellness-db
+    plan: free

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,7 @@ typing_extensions==4.13.2
 celery==5.3.0
 redis==4.6.0
 django-celery-beat==2.5.0
+
+gunicorn==20.1.0
+dj-database-url==2.1.0
+whitenoise==6.6.0

--- a/wellness_project/settings.py
+++ b/wellness_project/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 from datetime import timedelta
 from pathlib import Path
 from decouple import config
+import dj_database_url
 import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -74,6 +75,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -270,6 +272,14 @@ DATABASES = {
     }
 }
 
+DATABASE_URL = config('DATABASE_URL', default=None)
+if DATABASE_URL:
+    DATABASES['default'] = dj_database_url.config(
+        default=DATABASE_URL,
+        conn_max_age=600,
+        ssl_require=True,
+    )
+
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators
 
@@ -299,6 +309,7 @@ USE_TZ = True
 # Static files
 STATIC_URL = 'static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Media files for recipe images
 MEDIA_URL = '/media/'

--- a/wellness_project/wsgi.py
+++ b/wellness_project/wsgi.py
@@ -10,7 +10,9 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise import WhiteNoise
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wellness_project.settings')
 
 application = get_wsgi_application()
+application = WhiteNoise(application)


### PR DESCRIPTION
## Summary
- add Render blueprint and usage docs
- install gunicorn, dj-database-url, and whitenoise
- configure database via `DATABASE_URL`
- enable WhiteNoise static file serving

## Testing
- `pytest -q` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686ae713caf8832bb651ab3e80b00d5d