### PR TITLE
Resolve chromadb module not found error

### DIFF
--- a/meal_planning/services/ai_meal_planning_service.py
+++ b/meal_planning/services/ai_meal_planning_service.py
@@ -14,9 +14,16 @@ from django.core.cache import cache
 from django.utils import timezone
 
 import openai
-import chromadb
 import numpy as np
 from openai import OpenAI
+
+# Conditional chromadb import for RAG capabilities
+try:
+    import chromadb
+    CHROMADB_AVAILABLE = True
+except ImportError:
+    chromadb = None
+    CHROMADB_AVAILABLE = False
 
 from ..models import (
     NutritionProfile, Recipe, Ingredient, MealPlan, 
@@ -78,6 +85,11 @@ class AdvancedAIMealPlanningService:
     
     def setup_vector_database(self):
         """Initialize ChromaDB for RAG capabilities"""
+        if not CHROMADB_AVAILABLE:
+            logger.warning("ChromaDB not available - RAG capabilities disabled. Install 'chromadb' for enhanced functionality.")
+            self.chroma_client = None
+            return
+            
         try:
             self.chroma_client = chromadb.PersistentClient(
                 path=getattr(settings, 'CHROMA_PERSIST_DIRECTORY', './chroma_db')

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ django-filter>=23.1,<24.0
 # Updated OpenAI with function calling support
 openai>=1.0.0,<2.0.0
 # Vector database and RAG support
+chromadb>=0.4.0,<1.0.0
 faiss-cpu>=1.7.0,<2.0.0
 sentence-transformers>=2.2.0,<3.0.0
 # Advanced nutrition analysis


### PR DESCRIPTION
Make chromadb import conditional and add it to requirements.txt to fix startup errors and enable optional RAG features.

The `ModuleNotFoundError` for `chromadb` was preventing the Django application from starting, despite existing fallback logic for meal plan generation. This PR ensures the application can always start by making the `chromadb` import conditional, allowing it to function without RAG capabilities if the dependency is not met, while also adding `chromadb` to `requirements.txt` for environments that wish to utilize the enhanced RAG features.

---

[Open in Web](https://www.cursor.com/agents?id=bc-eddbedcf-eefb-4cbf-aaa7-387dc471506a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-eddbedcf-eefb-4cbf-aaa7-387dc471506a)