### PR TITLE
Fix meal planning api timeout and implement full features

### DIFF
--- a/frontend/src/services/http.service.js
+++ b/frontend/src/services/http.service.js
@@ -16,7 +16,7 @@ const apiClient = axios.create({
     headers: {
         'Content-Type': 'application/json',
     },
-    timeout: 30000,  // Increased timeout for service wake-up
+    timeout: 90000,  // Increased timeout for service wake-up
     withCredentials: true,   // if you need cookies/CORS creds
 });
 

--- a/frontend/src/services/mealPlanningApi.js
+++ b/frontend/src/services/mealPlanningApi.js
@@ -23,11 +23,14 @@ const API_ROOT = (process.env.VUE_APP_API_URL || DEFAULT_API_ROOT).replace(/\/ap
 const API_BASE_URL = `${API_ROOT}/meal-planning/api`;
 
 // Create axios instance with base configuration - MATCHING your http.service.js pattern
-// Increase timeout to 30 seconds (Render can take ~20-30 s to wake a sleeping service)
-// and enable credentials in case cookies are needed.
+// Increase timeout to 90 seconds because AI-powered meal-plan generation can
+// occasionally exceed 30 s, especially when the Render backend is waking up
+// from hibernation or when multiple sequential LLM calls are required.
+// Matching the http.service.js timeout keeps behaviour consistent across all
+// API clients.
 const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 30000,
+  timeout: 90000,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
Increase API request timeouts to prevent `ECONNABORTED` errors during AI-powered meal plan generation.

The previous 30-second timeout was insufficient for the AI pipeline (sequential LLM calls + RAG) to complete, particularly when the Render backend was waking from hibernation, leading to `timeout of 30000ms exceeded` errors.

---

[Open in Web](https://www.cursor.com/agents?id=bc-acf78f05-d00c-4d21-ad18-0f1fd763f44c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-acf78f05-d00c-4d21-ad18-0f1fd763f44c)