### PR TITLE
Fix meal planning api network errors

### DIFF
--- a/frontend/src/services/mealPlanningApi.js
+++ b/frontend/src/services/mealPlanningApi.js
@@ -3,7 +3,15 @@ import axios from 'axios';
 import AuthService from './auth.service';
 import store from '../store';
 
-const API_BASE_URL = 'http://localhost:8000/meal-planning/api';
+// Determine the Meal-Planning API base URL.
+// 1. If the build/runtime provides an explicit environment variable (Vue CLI uses the `VUE_APP_` prefix), use that.
+// 2. Otherwise fall back to a relative path so that requests go to the same host that served the front-end
+//    (works for both local development via a dev-server proxy and for production deployments on Render, etc.).
+
+const API_BASE_URL = (
+  process.env.VUE_APP_MEAL_PLANNING_API_URL ||
+  '/meal-planning/api'
+).replace(/\/+$/, '') + '/';
 
 // Create axios instance with base configuration - MATCHING your http.service.js pattern
 const api = axios.create({


### PR DESCRIPTION
Update Meal Planning API base URL to resolve CORS errors in deployed environments.

The previous hardcoded `localhost` API URL caused `XMLHttpRequest cannot load ... due to access control checks` and `Not allowed to request resource` errors when the frontend was deployed to a different domain (e.g., Render). This change allows the API URL to be configured via the `VUE_APP_MEAL_PLANNING_API_URL` environment variable or default to a relative path, ensuring requests are made to the correct backend host.

---

[Open in Web](https://www.cursor.com/agents?id=bc-39759629-c9a2-42a2-b1c6-1708b0ab16f5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-39759629-c9a2-42a2-b1c6-1708b0ab16f5)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)