### PR TITLE
Fix meal planning api network errors and remove dashboard card

### DIFF
--- a/frontend/src/services/mealPlanningApi.js
+++ b/frontend/src/services/mealPlanningApi.js
@@ -3,7 +3,19 @@ import axios from 'axios';
 import AuthService from './auth.service';
 import store from '../store';
 
-const API_BASE_URL = 'http://localhost:8000/meal-planning/api';
+// Determine API base-URL dynamically so it works in both development and production.
+// Priority: 1) explicit VUE_APP_MEAL_API_URL   2) generic VUE_APP_API_URL with /meal-planning path   3) Render default fallback
+
+const API_BASE_URL = (
+  // If a dedicated Meal-Planning URL is provided, use it as-is
+  process.env.VUE_APP_MEAL_API_URL ||
+  // Otherwise, reuse the generic API root (if present) and append the meal-planning postfix
+  (process.env.VUE_APP_API_URL
+    // Strip trailing /api or trailing slash, then append meal-planning path
+    ? process.env.VUE_APP_API_URL.replace(/\/api\/?$/, '').replace(/\/?$/, '') + '/meal-planning/api'
+    : null)
+  // Final fallback – public Render backend
+) || 'https://wellness-app-tx2c.onrender.com/meal-planning/api';
 
 // Create axios instance with base configuration - MATCHING your http.service.js pattern
 const api = axios.create({

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -121,11 +121,6 @@
         :milestones="achievedMilestones"
         @close="closeMilestoneModal"
       />
-
-      <meal-planning-card
-        class="dashboard-card"
-        @navigate-to-meal-planning="$router.push('/meal-planning')"
-      />
     </div>
   </div>
 </template>
@@ -146,12 +141,11 @@ import AddWeightModal from '../components/dashboard/AddWeightModal.vue';
 import MilestonesCard from '../components/dashboard/MilestonesCard.vue';
 import ActivitiesCard from '../components/dashboard/ActivitiesCard.vue';
 import MilestoneAchievementModal from '../components/dashboard/MilestoneAchievementModal.vue';
-import MealPlanningCard from "@/components/dashboard/MealPlanningCard.vue";
+// MealPlanningCard removed per request
 
 export default {
   name: 'Dashboard',
   components: {
-    MealPlanningCard,
     WellnessScoreCard,
     BmiStatusCard,
     ActivityLevelCard,


### PR DESCRIPTION
Fix Meal Planning API base URL to resolve CORS errors and remove the Meal Planning card from the dashboard.

The Meal Planning API was attempting to connect to `http://localhost:8000` even in deployed environments, leading to CORS (Cross-Origin Resource Sharing) errors. This PR updates the API base URL logic to correctly derive the backend URL from environment variables (`VUE_APP_MEAL_API_URL` or `VUE_APP_API_URL`) or a production fallback. Additionally, the Meal Planning card was removed from the dashboard as requested by the user due to ongoing issues with the feature.

---

[Open in Web](https://www.cursor.com/agents?id=bc-fa749b8c-09e5-459a-81e1-0b671b6691ef) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fa749b8c-09e5-459a-81e1-0b671b6691ef)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)