### PR TITLE
Fix logging file not found error

### DIFF
--- a/wellness_project/settings.py
+++ b/wellness_project/settings.py
@@ -16,6 +16,10 @@ import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Ensure logs directory exists for file-based logging handlers
+LOG_DIR = BASE_DIR / 'logs'
+LOG_DIR.mkdir(exist_ok=True)
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -637,13 +641,13 @@ LOGGING = {
         'file': {
             'level': 'INFO',
             'class': 'logging.FileHandler',
-            'filename': 'logs/nutrition.log',
+            'filename': str(LOG_DIR / 'nutrition.log'),
             'formatter': 'verbose',
         },
         'spoonacular': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': 'logs/spoonacular_api.log',
+            'filename': str(LOG_DIR / 'spoonacular_api.log'),
             'formatter': 'verbose',
         },
     },


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Create log directory and update log file paths to resolve `FileNotFoundError` during startup.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application failed to start due to `FileNotFoundError` when Django's logging configuration attempted to write to `nutrition.log` and `spoonacular_api.log` within a non-existent `logs/` directory. This PR ensures the `logs/` directory is created at startup and updates the log file paths to correctly reference this directory.

---

[Open in Web](https://cursor.com/agents?id=bc-3c8c1d5b-e841-49c7-9de7-fdb368904077) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3c8c1d5b-e841-49c7-9de7-fdb368904077)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)