### PR TITLE
Configure nutrition log file handler

### DIFF
--- a/wellness_project/settings.py
+++ b/wellness_project/settings.py
@@ -15,6 +15,8 @@ from decouple import config
 import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+# Ensure the logs directory exists to prevent FileNotFoundError when configuring file handlers
+(BASE_DIR / 'logs').mkdir(exist_ok=True)
 
 
 # Quick-start development settings - unsuitable for production
@@ -637,13 +639,13 @@ LOGGING = {
         'file': {
             'level': 'INFO',
             'class': 'logging.FileHandler',
-            'filename': 'logs/nutrition.log',
+            'filename': str(BASE_DIR / 'logs' / 'nutrition.log'),
             'formatter': 'verbose',
         },
         'spoonacular': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': 'logs/spoonacular_api.log',
+            'filename': str(BASE_DIR / 'logs' / 'spoonacular_api.log'),
             'formatter': 'verbose',
         },
     },


### PR DESCRIPTION
Configure Django logging to create log directory and use absolute paths to prevent `FileNotFoundError` during deployment.

The `FileNotFoundError` occurred because Django's file handlers attempted to write logs to `logs/nutrition.log` and `logs/spoonacular_api.log` within the container, but the `logs/` directory was not automatically created, causing the application to crash on startup. This fix ensures the directory exists and paths are correctly resolved.

---

[Open in Web](https://cursor.com/agents?id=bc-26de9b3e-44c2-4991-8527-8ab47493b8d2) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-26de9b3e-44c2-4991-8527-8ab47493b8d2)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)