### PR TITLE
Diagnose and fix api and network errors

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,7 +7,31 @@ import store from './store'
 // Import base styles
 import './assets/styles/main.scss'
 
-const app = createApp(App)
-app.use(store)
-app.use(router)
-app.mount('#app')
+// Service wake-up helper
+import { wakeupService } from './utils/serviceWakeup'
+
+/**
+ * Bootstraps the Vue application.
+ * Before mounting we try to ping the backend once so the first
+ * real API requests don’t hit a sleeping container and fail with 503/timeout.
+ * If the wake-up fails we still mount the app, the existing axios
+ * interceptors will handle retries when the user performs actions.
+ */
+async function bootstrap() {
+  try {
+    // Attempt to wake the service in the background (no progress UI here)
+    await wakeupService(false)
+    console.log('✅ Backend service is awake')
+  } catch (err) {
+    console.warn('⚠️  Backend wake-up failed or timed out:', err?.message || err)
+    // Continue – axios interceptors will still retry on demand
+  }
+
+  const app = createApp(App)
+  app.use(store)
+  app.use(router)
+  app.mount('#app')
+}
+
+// Run the bootstrap sequence
+bootstrap()


### PR DESCRIPTION
Add a warm-up request to the backend on app initialization to prevent initial API request failures.

On Render's free tier, services hibernate after inactivity. The first few API calls to a sleeping backend often result in 503 errors or timeouts. This change sends a non-critical request to `/api/health/` to wake up the backend before the main application loads, improving the reliability of subsequent API calls.

---

[Open in Web](https://cursor.com/agents?id=bc-82b2ef9f-1278-428b-a758-a54b0ee896a8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-82b2ef9f-1278-428b-a758-a54b0ee896a8)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)