### PR TITLE
Troubleshoot sass build error

### DIFF
--- a/frontend/src/components/meal-planning/MealPlanDetailModal.vue
+++ b/frontend/src/components/meal-planning/MealPlanDetailModal.vue
@@ -845,6 +845,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '@/assets/styles/variables';
+
 $primary: #007bff;
 $secondary: #6c757d;
 $success: #28a745;
@@ -857,7 +859,6 @@ $white: #ffffff;
 $gray: #6c757d;
 $gray-light: #adb5bd;
 $gray-lighter: #e9ecef;
-$error: #dc3545;
 
 .modal-overlay {
   position: fixed;


### PR DESCRIPTION
Fixes build failure by importing global SCSS variables and removing conflicting local redefinition of `$error`.

The build failed because `MealPlanDetailModal.vue` attempted to redefine the `$error` SCSS variable locally, conflicting with a global definition in `_variables.scss`, and was not importing the global variables. This led to an "Undefined variable" error during compilation. The fix ensures the component uses the globally defined `$error` by importing `_variables.scss` and removing the redundant local definition.

---
<a href="https://cursor.com/background-agent?bcId=bc-82336176-da8e-4b6c-af6a-941888fc1225">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82336176-da8e-4b6c-af6a-941888fc1225">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>