### PR TITLE
Fix vue parsing error and warnings

### DIFF
--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -399,7 +399,7 @@
                   <span class="spinner"></span>
                   Saving...
                 </span>
-                <span v-else">Save Profile</span>
+                <span v-else>Save Profile</span>
               </button>
             </div>
           </form>


### PR DESCRIPTION
Fix parsing error in `Profile.vue` by removing an extra quote from a `v-else` directive.

---
<a href="https://cursor.com/background-agent?bcId=bc-a926c4af-2c2d-44d9-95a3-32620db54214">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a926c4af-2c2d-44d9-95a3-32620db54214">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>