### PR TITLE
Fix frontend module not found error

### DIFF
--- a/frontend/src/services/aiAssistantService.js
+++ b/frontend/src/services/aiAssistantService.js
@@ -1,5 +1,5 @@
 // services/aiAssistantService.js
-import api from './api';
+import api from './http.service';
 
 const AI_ASSISTANT_BASE_URL = '/ai-assistant';
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,5 @@
 // Export the apiClient from http.service.js
+// This file serves as a convenient alias for the http.service module
 import apiClient from './http.service';
 
 export default apiClient;


### PR DESCRIPTION
Directly import `http.service` in `aiAssistantService` to fix a module resolution error during build.

The build on Render was failing with a "Module not found: Can't resolve './api'" error. By having `aiAssistantService.js` import `apiClient` directly from `http.service.js` instead of through the `api.js` intermediary, we bypass the resolution issue that was occurring in the build environment. `api.js` was merely re-exporting `http.service`, so this change maintains functionality while resolving the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-24453efc-afa7-45d6-a151-d5ff73a873f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24453efc-afa7-45d6-a151-d5ff73a873f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

